### PR TITLE
Changed the control notebook to use Linearizer

### DIFF
--- a/notebooks/exercise_solutions/n09_control_input-matrix.py
+++ b/notebooks/exercise_solutions/n09_control_input-matrix.py
@@ -1,1 +1,0 @@
-B = dot(inv(M), F_B)

--- a/notebooks/exercise_solutions/n09_control_linearize-forcing-vector.py
+++ b/notebooks/exercise_solutions/n09_control_linearize-forcing-vector.py
@@ -1,4 +1,0 @@
-F_B = forcing_vector.jacobian(specified)
-F_B = F_B.subs(equilibrium_dict).subs(parameter_dict)
-F_B = matrix2numpy(F_B, dtype=float)
-F_B

--- a/notebooks/exercise_solutions/n09_control_snippit.py
+++ b/notebooks/exercise_solutions/n09_control_snippit.py
@@ -5,37 +5,23 @@
 from numpy import matrix, dot, asarray
 from numpy.linalg import inv
 from scipy.linalg import solve_continuous_are
+from sympy import Matrix
 
-## from .utils import controllable
-## from .visualization import *
-
-## equilibrium_point = zeros(len(coordinates + speeds))
-## equilibrium_dict = dict(zip(coordinates + speeds, equilibrium_point))
 parameter_dict = dict(zip(constants, numerical_constants))
 
-linear_state_matrix, linear_input_matrix, inputs = \
-    kane.linearize(new_method=True, A_and_B=True)
-f_A_lin = linear_state_matrix.subs(parameter_dict).subs(equilibrium_dict)
-f_B_lin = linear_input_matrix.subs(parameter_dict).subs(equilibrium_dict)
-m_mat = mass_matrix.subs(parameter_dict).subs(equilibrium_dict)
+linearizer = kane.to_linearizer()
+linearizer.r = Matrix(specified)
+A, B = linearizer.linearize(op_point=[equilibrium_dict, parameter_dict],
+                            A_and_B=True)
 
-A = matrix(m_mat.inv() * f_A_lin).astype(float)
-B = matrix(m_mat.inv() * f_B_lin).astype(float)
+A = matrix(A).astype(float)
+B = matrix(B).astype(float)
 
 S = solve_continuous_are(A, B, Q, R)
 
 K = inv(R) * B.T * S
 
-# This is an annoying little issue. We specified the order of things when
-# creating the rhs function, but the linearize function returns the F_B
-# matrix in the order corresponding to whatever order it finds the joint
-# torques. This would also screw things up if we specified a different
-# ordering of the coordinates and speeds as the standard kana._q + kane._u
-
-K = K[[0, 2, 1], :]
-
-
 def controller(x, t):
-    return -asarray(dot(K, x)).flatten()
+    return -dot(K, x)
 
 y = odeint(right_hand_side, x0, t, args=(controller, numerical_constants))

--- a/notebooks/n09_control.ipynb
+++ b/notebooks/n09_control.ipynb
@@ -113,7 +113,7 @@
    },
    "outputs": [],
    "source": [
-    "from sympy import simplify, matrix2numpy\n",
+    "from sympy import simplify, Matrix, matrix2numpy\n",
     "from sympy.physics.vector import init_vprinting, vlatex"
    ]
   },
@@ -262,25 +262,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can compute the Jacobian of the forcing vector with respect to the states and the inputs using the `jacobian()` method."
+    "The `KanesMethod` object from earlier contains methods for linearizing the equations of motion. First, we'll create a `Linearizer` object:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "F_A = forcing_vector.jacobian(coordinates + speeds)"
+    "linearizer = kane.to_linearizer()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First substitute in the equilibrium point values:"
+    "This creates an object that holds a *generalized form* of the equations of motion, which can be used to linearize the system in a robust way. When it does this, it finds the inputs `r`, and orders them alphabetically. We have our own order we want to use from before, so we need to change this:"
    ]
   },
   {
@@ -291,15 +291,25 @@
    },
    "outputs": [],
    "source": [
-    "F_A = simplify(F_A.subs(equilibrium_dict))\n",
-    "F_A"
+    "linearizer.r == Matrix(specified)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "linearizer.r = Matrix(specified)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's substitute in the numerical values for the constants and convert to a floating point NumPy array:"
+    "To perform the actual linearization, we'll use the `linearize` method:"
    ]
   },
   {
@@ -310,49 +320,36 @@
    },
    "outputs": [],
    "source": [
-    "F_A = matrix2numpy(F_A.subs(parameter_dict), dtype=float)\n",
-    "print(F_A)"
+    "help(linearizer.linearize)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercise"
+    "Because we want to get the equations in the form\n",
+    "\n",
+    "$$ \\Delta \\dot{x} = \\mathbf{A} \\Delta \\mathbf{x} + \\mathbf{B} \\Delta \\mathbf{u} $$\n",
+    "\n",
+    "we'll set `A_and_B=True`. We can also perform the variable to numeric substitution in this step by passing in both the `equilibrium_dict` and the `parameter_dict` to the operating point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "A, B = linearizer.linearize(op_point=[equilibrium_dict, parameter_dict], A_and_B=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Linearize the forcing vector with respect to the specified inputs by computing the correct Jacobian and creating a numerical array for $\\mathbf{f}_B$."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%load exercise_solutions/n09_control_linearize-forcing-vector.py"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We also need the mass matrix evaluated at the equilibrium and with the numerical values of the constants."
+    "Now we can convert from symbolic to numeric numpy matrices, and display our results:"
    ]
   },
   {
@@ -363,8 +360,8 @@
    },
    "outputs": [],
    "source": [
-    "M = mass_matrix.subs(equilibrium_dict)\n",
-    "simplify(M)"
+    "A = matrix2numpy(A, dtype=float)\n",
+    "B = matrix2numpy(B, dtype=float)"
    ]
   },
   {
@@ -375,15 +372,7 @@
    },
    "outputs": [],
    "source": [
-    "M = matrix2numpy(M.subs(parameter_dict), dtype=float)\n",
-    "print(M)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can use the NumPy matrix multiplication function `dot()` and the matrix inverse function `inv()` to compute the state $\\mathbf{A}$ and input $\\mathbf{B}$ matrices we need to create the controller."
+    "A"
    ]
   },
   {
@@ -394,63 +383,7 @@
    },
    "outputs": [],
    "source": [
-    "A = dot(inv(M), F_A)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "print(A)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Exercise"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create the input matrix, $\\mathbf{B}$ using `dot()` and `inv()`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%load exercise_solutions/n09_control_input-matrix.py"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "print(B)"
+    "B"
    ]
   },
   {
@@ -659,7 +592,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -851,7 +784,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": []


### PR DESCRIPTION
Notebook 9 (control) now uses the `Linearizer` class to perform the linearization.

TODO:
- [ ] More exercises to replace the ones I removed?
- [ ] `odeint` currently times-out after the constants are changed, due to the controller not properly stabilizing the system (I think). Not sure what's up, the matrices generated by linearizing this way are equivalent to before.

Closes #77.