### PR TITLE
Added a depencency on older version of ipywidgets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,10 @@ Now install the latest PyDy with::
 
    $ conda install -c pydy pydy
 
+Lastly we are using an older version of ipywidgets and so you may need to issue
+the following command to terminal::
+
+   $ pip install ipywidgets==4.1.1
 
 MathJax
 -------

--- a/check_env.py
+++ b/check_env.py
@@ -2,7 +2,8 @@
 
 from distutils.version import LooseVersion
 
-for module in ['IPython', 'sympy', 'pydy', 'numpy', 'scipy', 'matplotlib']:
+for module in ['IPython', 'sympy', 'pydy', 'numpy', 'scipy', 'matplotlib',
+               'ipywidgets']:
     try:
         __import__(module)
     except ImportError:
@@ -32,6 +33,14 @@ else:
             __import__('ipywidgets')
         except ImportError:
             print('Error: ipywidgets is required for IPython >= 4.0')
+
+try:
+    import ipywidgets
+except ImportError:
+    pass
+else:
+    if LooseVersion(ipywidgets.__version__) >= LooseVersion('5.0.0'):
+        print('Error: ipywidgets < 5.0 is required for tutorial')
 
 try:
     import pydy


### PR DESCRIPTION
This change signifies that we are using a 4.X version of ipywidgets for
this tutorial. This information has been added to the README and the
environment checker.