### PR TITLE
Fixed bug in the 6th notebook

### DIFF
--- a/notebooks/n06_equations_of_motion.ipynb
+++ b/notebooks/n06_equations_of_motion.ipynb
@@ -228,7 +228,7 @@
    },
    "outputs": [],
    "source": [
-    "fr, frstar = kane.kanes_equations(loads, bodies)"
+    "fr, frstar = kane.kanes_equations(bodies, loads)"
    ]
   },
   {
@@ -311,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/solution/equations_of_motion.py
+++ b/notebooks/solution/equations_of_motion.py
@@ -25,7 +25,7 @@ loads = [lower_leg_grav_force,
 
 bodies = [lower_leg, upper_leg, torso]
 
-fr, frstar = kane.kanes_equations(loads, bodies)
+fr, frstar = kane.kanes_equations(bodies, loads)
 
 mass_matrix = kane.mass_matrix_full
 forcing_vector = kane.forcing_full


### PR DESCRIPTION
Recently the input order for kanes_equations was reversed. This commit
changes the tutorial to match the input reversal. The change was made
both in the notebook and the solution file.