### PR TITLE
Change argument order of kanes_equation()

### DIFF
--- a/notebooks/n06_equations_of_motion.ipynb
+++ b/notebooks/n06_equations_of_motion.ipynb
@@ -228,7 +228,7 @@
    },
    "outputs": [],
    "source": [
-    "fr, frstar = kane.kanes_equations(loads, bodies)"
+    "fr, frstar = kane.kanes_equations(bodies, loads)"
    ]
   },
   {

--- a/notebooks/solution/equations_of_motion.py
+++ b/notebooks/solution/equations_of_motion.py
@@ -25,7 +25,7 @@ loads = [lower_leg_grav_force,
 
 bodies = [lower_leg, upper_leg, torso]
 
-fr, frstar = kane.kanes_equations(loads, bodies)
+fr, frstar = kane.kanes_equations(bodies, loads)
 
 mass_matrix = kane.mass_matrix_full
 forcing_vector = kane.forcing_full


### PR DESCRIPTION
The kanes_equation() argument order has been deprecated since SymPy 1.1. Use switched argument order to update your code, For example: kanes_equations(loads, bodies) > kanes_equations(bodies, loads).

A warning was generated when I was using the old argument order.